### PR TITLE
Add support of get_terminal_size on windows terminal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,23 +8,23 @@
 
 ### How Has This Been Tested? ###
 
-| Architecture | Yes/No                   | Comments               |
-|--------------|:------------------------:|------------------------|
+| Architecture |          Yes/No          | Comments                                  |
+| ------------ | :----------------------: | ----------------------------------------- |
 | x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
-| x86-64       | :heavy_multiplication_x: |                        |
-| ARM          | :heavy_multiplication_x: |                        |
-| AARCH64      | :heavy_multiplication_x: |                        |
-| MIPS         | :heavy_multiplication_x: |                        |
-| POWERPC      | :heavy_multiplication_x: |                        |
-| SPARC        | :heavy_multiplication_x: |                        |
-| `make tests` | :heavy_multiplication_x: |                        |
+| x86-64       | :heavy_multiplication_x: |                                           |
+| ARM          | :heavy_multiplication_x: |                                           |
+| AARCH64      | :heavy_multiplication_x: |                                           |
+| MIPS         | :heavy_multiplication_x: |                                           |
+| POWERPC      | :heavy_multiplication_x: |                                           |
+| SPARC        | :heavy_multiplication_x: |                                           |
+| `make tests` | :heavy_multiplication_x: |                                           |
 
 ### Checklist ###
 
 <!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
 <!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
-- [ ] My code follows the code style of this project.
-- [ ] My change includes a change to the documentation, if required.
-- [ ] My change adds tests as appropriate.
-- [ ] I have read and agree to the **CONTRIBUTING** document.
+- [] My PR was done against the `dev` branch, not `master`.
+- [] My code follows the code style of this project.
+- [] My change includes a change to the documentation, if required.
+- [] My change adds tests as appropriate.
+- [] I have read and agree to the **CONTRIBUTING** document.

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -2,10 +2,10 @@
 
 The `functions` command will list all of the [convenience functions](https://sourceware.org/gdb/onlinedocs/gdb/Convenience-Funs.html) provided by GEF.
 
+* `$_base([name])`     -- Return the base address of the matching section (default current file).
 * `$_bss([offset])`    -- Return the current bss base address plus the given offset.
 * `$_got([offset])`    -- Return the current bss base address plus the given offset.
 * `$_heap([offset])`   -- Return the current heap base address plus an optional offset.
-* `$_pie([offset])`    -- Return the current pie base address plus an optional offset.
 * `$_stack([offset])`  -- Return the current stack base address plus an optional offset.
 
 

--- a/gef.py
+++ b/gef.py
@@ -9942,6 +9942,10 @@ def __gef_prompt__(current_prompt):
 
 if __name__  == "__main__":
 
+    if PYTHON_MAJOR == 2:
+        warn("GEF will stop support for GDB+Python2 when it reaches EOL on 2020/01/01.")
+        warn("See https://github.com/hugsy/gef/projects/4 for updates.")
+
     if GDB_VERSION < GDB_MIN_VERSION:
         err("You're using an old version of GDB. GEF will not work correctly. "
             "Consider updating to GDB {} or higher.".format(".".join(map(str, GDB_MIN_VERSION))))

--- a/gef.py
+++ b/gef.py
@@ -2199,7 +2199,6 @@ class SPARC(Architecture):
         return False
 
     def is_ret(self, insn):
-        # TODO: rett?
         return insn.mnemonic == "ret"
 
     def is_conditional_branch(self, insn):

--- a/gef.py
+++ b/gef.py
@@ -61,7 +61,6 @@ import binascii
 import codecs
 import collections
 import ctypes
-import fcntl
 import functools
 import getopt
 import hashlib
@@ -79,7 +78,6 @@ import struct
 import subprocess
 import sys
 import tempfile
-import termios
 import time
 import traceback
 
@@ -2873,13 +2871,27 @@ def get_terminal_size():
     if is_debug():
         return 600, 100
 
-    try:
-        cmd = struct.unpack("hh", fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"))
-        tty_rows, tty_columns = int(cmd[0]), int(cmd[1])
-        return tty_rows, tty_columns
-
-    except OSError:
-        return 600, 100
+    if platform.system() == "Windows":
+        from ctypes import windll, create_string_buffer
+        hStdErr = -12
+        herr = windll.kernel32.GetStdHandle(hStdErr)
+        csbi = create_string_buffer(22)
+        res = windll.kernel32.GetConsoleScreenBufferInfo(herr, csbi)
+        if res:
+            _,_,_,_,_, left, top, right, bottom, _,_ = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            tty_columns = right - left + 1
+            tty_rows = bottom - top + 1
+            return tty_rows, tty_columns
+        else:
+            return 600,100
+    else:
+        import fcntl
+        import termios
+        try:
+            tty_rows, tty_columns = struct.unpack("hh", fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"))
+            return tty_rows, tty_columns
+        except OSError:
+            return 600, 100
 
 
 def get_generic_arch(module, prefix, arch, mode, big_endian, to_string=False):

--- a/gef.py
+++ b/gef.py
@@ -9974,7 +9974,6 @@ if __name__  == "__main__":
         gdb.execute("set confirm off")
         gdb.execute("set verbose off")
         gdb.execute("set pagination off")
-        gdb.execute("set step-mode on")
         gdb.execute("set print elements 0")
 
         # gdb history

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -504,7 +504,7 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
             "highlight add 42424242 blue",
             "highlight add 43434343 green",
             "highlight add 44444444 pink",
-            'set $rsp = "AAAABBBBCCCCDDDD"',
+            'patch string $rsp "AAAABBBBCCCCDDDD"',
             "hexdump qword $rsp 2"
         ]
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -557,18 +557,20 @@ class TestGefFunctions(GefUnitTestGeneric):
 class TestGdbFunctions(GefUnitTestGeneric):
     """Tests gdb convenience functions added by GEF."""
 
-    def test_func_pie(self):
-        cmd = "x/s $_pie()"
+    def test_func_base(self):
+        cmd = "x/s $_base()"
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
         self.assertIn("\\177ELF", res)
+        addr = res.splitlines()[-1].split()[0][:-1]
 
-        cmd = "x/s $_pie(1)"
+        cmd = "x/s $_base(\"libc\")"
         res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
-        self.assertNotIn("\\177ELF", res)
-        self.assertIn("ELF", res)
+        self.assertIn("\\177ELF", res)
+        addr2 = res.splitlines()[-1].split()[0][:-1]
+        self.assertNotEqual(addr, addr2)
         return
 
     def test_func_heap(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -62,15 +62,15 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
 
         target = "tests/binaries/checksec-no-canary.out"
         res = gdb_run_cmd(cmd, target=target)
-        self.assertIn("Canary                        : No", res)
+        self.assertIn("Canary                        : ✘", res)
 
         target = "tests/binaries/checksec-no-nx.out"
         res = gdb_run_cmd(cmd, target=target)
-        self.assertIn("NX                            : No", res)
+        self.assertIn("NX                            : ✘", res)
 
         target = "tests/binaries/checksec-no-pie.out"
         res = gdb_run_cmd(cmd, target=target)
-        self.assertIn("PIE                           : No", res)
+        self.assertIn("PIE                           : ✘", res)
         return
 
     def test_cmd_dereference(self):


### PR DESCRIPTION
## <TITLE OF YOUR PATCH HERE> ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
- [ ] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [ ] I have read and agree to the **CONTRIBUTING** document.
